### PR TITLE
Bug fixes for delta scoring and user suspension

### DIFF
--- a/backend/services/attemptService/services/attemptService.ts
+++ b/backend/services/attemptService/services/attemptService.ts
@@ -70,6 +70,40 @@ export function calculateScoreDelta(difficulty: AttemptDifficulty, success: bool
     return 50;
 }
 
+function getAttemptTimestamp(attempt: AttemptRecord): number {
+    return attempt.attemptedAt.getTime();
+}
+
+function calculateAppliedDeltaFromHistory(
+    attempts: AttemptRecord[],
+    targetAttemptId: string,
+): number | null {
+    const orderedAttempts = [...attempts].sort((left, right) => {
+        const attemptedAtDiff = getAttemptTimestamp(left) - getAttemptTimestamp(right);
+        if (attemptedAtDiff !== 0) {
+            return attemptedAtDiff;
+        }
+
+        return left.createdAt.getTime() - right.createdAt.getTime();
+    });
+
+    let score = 0;
+
+    for (const attempt of orderedAttempts) {
+        const theoreticalDelta = calculateScoreDelta(attempt.difficulty, attempt.success);
+        const nextScore = Math.max(0, score + theoreticalDelta);
+        const appliedDelta = nextScore - score;
+
+        if (attempt.id === targetAttemptId) {
+            return appliedDelta;
+        }
+
+        score = nextScore;
+    }
+
+    return null;
+}
+
 export class AttemptService {
     private readonly userScoreService = new UserScoreService();
     private readonly qnPopularScoreService = new QuestionPopularityService();
@@ -116,7 +150,11 @@ export class AttemptService {
         let netDelta = newDelta;
 
         if (existing) {
-            const oldDelta = calculateScoreDelta(existing.difficulty, existing.success);
+            const attempts = await attemptRepository.listByClerkUserId(userId);
+            const oldDelta =
+                calculateAppliedDeltaFromHistory(attempts, existing.id) ??
+                calculateScoreDelta(existing.difficulty, existing.success);
+
             netDelta = newDelta - oldDelta;
             await attemptRepository.deleteByIds([existing.id]);
         }

--- a/backend/services/attemptService/services/attemptService.ts
+++ b/backend/services/attemptService/services/attemptService.ts
@@ -70,26 +70,16 @@ export function calculateScoreDelta(difficulty: AttemptDifficulty, success: bool
     return 50;
 }
 
-function getAttemptTimestamp(attempt: AttemptRecord): number {
-    return attempt.attemptedAt.getTime();
-}
-
 function calculateAppliedDeltaFromHistory(
     attempts: AttemptRecord[],
     targetAttemptId: string,
 ): number | null {
-    const orderedAttempts = [...attempts].sort((left, right) => {
-        const attemptedAtDiff = getAttemptTimestamp(left) - getAttemptTimestamp(right);
-        if (attemptedAtDiff !== 0) {
-            return attemptedAtDiff;
-        }
-
-        return left.createdAt.getTime() - right.createdAt.getTime();
-    });
-
     let score = 0;
 
-    for (const attempt of orderedAttempts) {
+    // listByClerkUserId returns newest-first, so replay from the tail to preserve
+    // the original score progression without re-sorting the full history.
+    for (let index = attempts.length - 1; index >= 0; index -= 1) {
+        const attempt = attempts[index];
         const theoreticalDelta = calculateScoreDelta(attempt.difficulty, attempt.success);
         const nextScore = Math.max(0, score + theoreticalDelta);
         const appliedDelta = nextScore - score;

--- a/backend/services/attemptService/tests/services/attemptService.test.ts
+++ b/backend/services/attemptService/tests/services/attemptService.test.ts
@@ -166,6 +166,118 @@ describe("AttemptService", () => {
         expect(deleteByIdsSpy).toHaveBeenCalledWith(["attempt-1"]);
     });
 
+    it("reverses only the applied contribution of a failed attempt when later attempts increased the score", async () => {
+        vi.spyOn(attemptRepository, "findByUserAndCollaboration").mockResolvedValue({
+            id: "attempt-1",
+            clerkUserId: "user_1",
+            questionId: "question-1",
+            questionTitle: "Two Sum",
+            collaborationId: "collab-1",
+            language: "typescript",
+            difficulty: "Hard",
+            success: false,
+            duration: 1200,
+            totalTestCases: 5,
+            testCasesPassed: 0,
+            attemptedAt: new Date("2026-03-24T00:00:00.000Z"),
+            createdAt: new Date("2026-03-24T00:00:00.000Z"),
+        });
+        vi.spyOn(attemptRepository, "listByClerkUserId").mockResolvedValue([
+            {
+                id: "attempt-3",
+                clerkUserId: "user_1",
+                questionId: "question-3",
+                questionTitle: "Medium Problem",
+                collaborationId: "collab-3",
+                language: "typescript",
+                difficulty: "Medium",
+                success: true,
+                duration: 1200,
+                totalTestCases: 5,
+                testCasesPassed: 5,
+                attemptedAt: new Date("2026-03-25T00:00:00.000Z"),
+                createdAt: new Date("2026-03-25T00:00:00.000Z"),
+            },
+            {
+                id: "attempt-4",
+                clerkUserId: "user_1",
+                questionId: "question-4",
+                questionTitle: "Easy Problem",
+                collaborationId: "collab-4",
+                language: "typescript",
+                difficulty: "Easy",
+                success: true,
+                duration: 1200,
+                totalTestCases: 5,
+                testCasesPassed: 5,
+                attemptedAt: new Date("2026-03-26T00:00:00.000Z"),
+                createdAt: new Date("2026-03-26T00:00:00.000Z"),
+            },
+            {
+                id: "attempt-1",
+                clerkUserId: "user_1",
+                questionId: "question-1",
+                questionTitle: "Two Sum",
+                collaborationId: "collab-1",
+                language: "typescript",
+                difficulty: "Hard",
+                success: false,
+                duration: 1200,
+                totalTestCases: 5,
+                testCasesPassed: 0,
+                attemptedAt: new Date("2026-03-24T00:00:00.000Z"),
+                createdAt: new Date("2026-03-24T00:00:00.000Z"),
+            },
+        ]);
+        vi.spyOn(attemptRepository, "deleteByIds").mockResolvedValue();
+        vi.spyOn(attemptRepository, "insert").mockResolvedValue({
+            id: "attempt-2",
+            clerkUserId: "user_1",
+            questionId: "question-1",
+            questionTitle: "Two Sum",
+            collaborationId: "collab-1",
+            language: "typescript",
+            difficulty: "Hard",
+            success: true,
+            duration: 1200,
+            totalTestCases: 5,
+            testCasesPassed: 5,
+            attemptedAt: new Date("2026-03-25T00:00:00.000Z"),
+            createdAt: new Date("2026-03-25T00:00:00.000Z"),
+        });
+        const applyScoreDeltasSpy = vi
+            .spyOn(UserScoreService.prototype, "applyScoreDeltas")
+            .mockResolvedValue([
+                {
+                    clerkUserId: "user_1",
+                    previousScore: 40,
+                    newScore: 90,
+                    delta: 50,
+                },
+            ]);
+
+        const service = new AttemptService();
+        await service.recordAttempt({
+            userId: "user_1",
+            collaborationId: "collab-1",
+            questionId: "question-1",
+            questionTitle: "Two Sum",
+            language: "typescript",
+            difficulty: "Hard",
+            success: true,
+            duration: 1200,
+            totalTestCases: 5,
+            testCasesPassed: 5,
+        });
+
+        expect(applyScoreDeltasSpy).toHaveBeenCalledWith([
+            {
+                clerkUserId: "user_1",
+                delta: 50,
+            },
+        ]);
+    });
+
     it("returns attempt history from stored attempt records", async () => {
         vi.spyOn(attemptRepository, "listByClerkUserId").mockResolvedValue([
             {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - gateway
     env_file:
       - ./.env
-    command: http --url=nonjuridical-unflaunting-hudson.ngrok-free.dev --pooling-enabled=true gateway:8080
+    command: http --url=nonjuridical-unflaunting-hudson.ngrok-free.dev gateway:8080
     ports:
       - "4040:4040"
     networks:
@@ -174,7 +174,6 @@ services:
       - questions-db-network
     restart: unless-stopped
 
-
   questions-db:
     image: postgres:16-alpine
     container_name: questions-db
@@ -184,10 +183,10 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: questions
-      
+
     volumes:
       - questions_data:/var/lib/postgresql
-      
+
     networks:
       - questions-db-network
     restart: unless-stopped
@@ -206,7 +205,7 @@ services:
       - questions-db-network
     # ports:
     #   - "5432:5432"
-      
+
   # Collaboration Service
   collaboration-service:
     build: ./backend/services/collaborationService
@@ -332,7 +331,7 @@ services:
     image: rabbitmq:4.2-management
     container_name: peerprep-rabbitmq
     ports:
-      - "5672:5672"   # AMQP protocol port (for your Node app)
+      - "5672:5672" # AMQP protocol port (for your Node app)
       - "15672:15672" # Management UI (username: guest / password: guest)
     healthcheck:
       test: rabbitmq-diagnostics -q ping

--- a/frontend/src/context/AuthInterceptorProvider.tsx
+++ b/frontend/src/context/AuthInterceptorProvider.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
 
-import { useAuth } from "@clerk/clerk-react";
+import { useAuth, useClerk } from "@clerk/clerk-react";
 
-import { injectAuthInterceptor } from "@/utils/apiClient";
+import { injectAuthFailureHandler, injectAuthInterceptor } from "@/utils/apiClient";
+import { pushToast } from "@/utils/toast";
 
 type Props = {
     children: React.ReactNode;
@@ -10,6 +11,7 @@ type Props = {
 
 export function AuthInterceptorProvider({ children }: Props) {
     const { getToken, isLoaded, isSignedIn } = useAuth();
+    const { signOut } = useClerk();
 
     useEffect(() => {
         if (!isLoaded) {
@@ -24,6 +26,36 @@ export function AuthInterceptorProvider({ children }: Props) {
             injectAuthInterceptor(undefined);
         }
     }, [getToken, isLoaded, isSignedIn]);
+
+    useEffect(() => {
+        if (!isLoaded) {
+            return;
+        }
+
+        let hasHandledAuthFailure = false;
+
+        injectAuthFailureHandler((reason) => {
+            if (hasHandledAuthFailure || !isSignedIn) {
+                return;
+            }
+
+            hasHandledAuthFailure = true;
+
+            pushToast({
+                tone: "error",
+                message:
+                    reason === "inactive"
+                        ? "Your account has been suspended. Signing you out."
+                        : "Your session has expired. Signing you out.",
+            });
+
+            void signOut({ redirectUrl: "/account/login" });
+        });
+
+        return () => {
+            injectAuthFailureHandler(undefined);
+        };
+    }, [isLoaded, isSignedIn, signOut]);
 
     if (!isLoaded) {
         return null;

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,4 +1,5 @@
 type TokenGetter = (options?: { template?: string }) => Promise<string | null>;
+type AuthFailureHandler = (reason: "unauthorized" | "inactive") => void;
 
 type ApiRequestInit = RequestInit & {
     tokenTemplate?: string;
@@ -6,6 +7,7 @@ type ApiRequestInit = RequestInit & {
 };
 
 let getTokenRef: TokenGetter | undefined;
+let authFailureHandlerRef: AuthFailureHandler | undefined;
 let resolveAuthInterceptorReady: ((value: TokenGetter | undefined) => void) | undefined;
 let authInterceptorReady = false;
 const authInterceptorReadyPromise = new Promise<TokenGetter | undefined>((resolve) => {
@@ -20,6 +22,10 @@ export function injectAuthInterceptor(getToken?: TokenGetter): void {
         resolveAuthInterceptorReady?.(getToken);
         resolveAuthInterceptorReady = undefined;
     }
+}
+
+export function injectAuthFailureHandler(handler?: AuthFailureHandler): void {
+    authFailureHandlerRef = handler;
 }
 
 async function waitForAuthInterceptor(): Promise<TokenGetter | undefined> {
@@ -65,11 +71,29 @@ export async function apiFetch(url: string, init: ApiRequestInit = {}): Promise<
 
     // Since API_ENDPOINTS already contain the full gateway URL,
     // we just fetch the URL directly.
-    return fetch(url, {
+    const response = await fetch(url, {
         ...rest,
         headers,
         credentials: credentials ?? "include",
     });
+
+    if (response.status === 401) {
+        authFailureHandlerRef?.("unauthorized");
+        return response;
+    }
+
+    if (response.status === 403) {
+        const payload = await response
+            .clone()
+            .json()
+            .catch(() => null) as { error?: string } | null;
+
+        if (payload?.error === "Forbidden: account is not active.") {
+            authFailureHandlerRef?.("inactive");
+        }
+    }
+
+    return response;
 }
 
 export async function getAuthToken(): Promise<string | null> {

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -83,10 +83,10 @@ export async function apiFetch(url: string, init: ApiRequestInit = {}): Promise<
     }
 
     if (response.status === 403) {
-        const payload = await response
+        const payload = (await response
             .clone()
             .json()
-            .catch(() => null) as { error?: string } | null;
+            .catch(() => null)) as { error?: string } | null;
 
         if (payload?.error === "Forbidden: account is not active.") {
             authFailureHandlerRef?.("inactive");


### PR DESCRIPTION
Bug fixes:
1. Previously, overwrite scoring reversed the old attempt using its theoretical delta from difficulty + success. That breaks when the old failed attempt happened while the user’s score was already 0, because the actual applied delta was clamped to 0, not -10. 
e.g. Hard fail -> Medium success -> Easy success -> Hard success resulting in 30 + 10 + 60 instead of 30 + 10 + 50.

Now, overwrite handling will compute the old attempt’s actual applied contribution by replaying the user’s attempt history in chronological order and applying the same score clamping logic. The overwrite then reverses that applied contribution instead of the raw theoretical delta.

2. Immediately sign out suspended users on next API request that uses ApiFetch

3. Also disabled ngrok pooling cos we're moving out of dev soon