### PR TITLE
Fix(Session End State)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,7 +1123,8 @@ Operation history is capped at 50 entries. Server uses `priority: "right"` (exis
                   |  +-------------+                        |
                   |                                         |
                   +----- if other user is also              |
-                         LEFT or DISCONNECTED: -------------+
+                         LEFT or DISCONNECTED               |
+                         (with grace expired): -------------+
                                     |
                                     v
                               +-----------+
@@ -1137,7 +1138,7 @@ Operation history is capped at 50 entries. Server uses `priority: "right"` (exis
 | Rejoin? | Yes (within 3 min grace period) | No (permanent) |
 | Active session index | Kept (user sees rejoin prompt) | Cleared |
 | Other user sees | `user:disconnected` | `user:left` |
-| Session ends? | No (stays active) | Yes, if partner is LEFT or DISCONNECTED |
+| Session ends? | No (stays active) | Yes, if partner is LEFT or DISCONNECTED with expired grace period. If partner is DISCONNECTED within grace, session stays alive until grace expires (periodic check cleans up). |
 
 **Multi-tab synchronization:** Each browser tab opens a separate Socket.IO connection. All sockets for the same user in the same session share presence state in Redis. OT operations, execution results, and hints are broadcast to the Socket.IO room, so every tab receives them. A user is only marked `DISCONNECTED` when **all** their sockets close (socketCount reaches 0). `session:leave` only removes the triggering socket -- the user is only marked `LEFT` when their last socket triggers it. This means closing one tab doesn't disrupt the session if other tabs remain open.
 
@@ -1167,7 +1168,7 @@ The prompt has two modes: if code exists, it analyzes for bugs/missing logic; if
 
 #### Session End
 
-Sessions end via: **both users left**, **inactivity timeout** (30min, checked every 60s with a Redis distributed lock for horizontal scaling), or **manual** `endSession` call. On end: session marked inactive, user active-session indices cleared, all Redis data cleaned up (session, presence, OT doc, output, hints), `session:ended` emitted.
+Sessions end via: **both users left**, **one left + partner's disconnect grace period expired** (deferred end -- the periodic check cleans up once the 3-min grace expires, giving the disconnected user a chance to reconnect), **inactivity timeout** (30min, checked every 60s with a Redis distributed lock for horizontal scaling), or **manual** `endSession` call. On end: session marked inactive, user active-session indices cleared, all Redis data cleaned up (session, presence, OT doc, output, hints), `session:ended` emitted.
 
 #### Graceful Shutdown
 

--- a/backend/services/collaborationService/src/services/collaborationSessionService.ts
+++ b/backend/services/collaborationService/src/services/collaborationSessionService.ts
@@ -689,11 +689,17 @@ export class CollaborationSessionService {
     }
 
     /**
-     * F4.8.3 - Check for inactive sessions
+     * F4.8.3 - Single-pass cleanup check for inactive and grace-expired sessions.
+     * Scans active sessions once and checks both inactivity and grace-expiry conditions,
+     * reducing Redis load compared to two separate scans.
      */
-    async getInactiveSessions(inactivityTimeoutMs: number): Promise<string[]> {
+    async getSessionsToCleanup(
+        inactivityTimeoutMs: number,
+        gracePeriodMs: number,
+    ): Promise<{ inactiveIds: string[]; graceExpiredIds: string[] }> {
         const activeSessions = await this.redisSessionRepository.getActiveSessions();
-        const inactiveSessionIds: string[] = [];
+        const inactiveIds: string[] = [];
+        const graceExpiredIds: string[] = [];
 
         for (const session of activeSessions) {
             const isInactive = await this.redisPresenceRepository.isSessionInactive(
@@ -701,22 +707,10 @@ export class CollaborationSessionService {
                 inactivityTimeoutMs,
             );
             if (isInactive) {
-                inactiveSessionIds.push(session.collaborationId);
+                inactiveIds.push(session.collaborationId);
+                continue;
             }
-        }
 
-        return inactiveSessionIds;
-    }
-
-    /**
-     * Find sessions where one user has left and the other user's disconnect grace period has expired.
-     * Called by the periodic inactivity check to clean up deferred session ends.
-     */
-    async getSessionsWithExpiredGrace(gracePeriodMs: number): Promise<string[]> {
-        const activeSessions = await this.redisSessionRepository.getActiveSessions();
-        const expiredSessionIds: string[] = [];
-
-        for (const session of activeSessions) {
             const assignedUserIds = [session.userAId, session.userBId];
             const participants = await this.redisPresenceRepository.getParticipants(
                 session.collaborationId,
@@ -734,12 +728,12 @@ export class CollaborationSessionService {
                         gracePeriodMs,
                     );
                 if (!rejoinCheck.canRejoin) {
-                    expiredSessionIds.push(session.collaborationId);
+                    graceExpiredIds.push(session.collaborationId);
                 }
             }
         }
 
-        return expiredSessionIds;
+        return { inactiveIds, graceExpiredIds };
     }
 
     /**

--- a/backend/services/collaborationService/src/services/collaborationSessionService.ts
+++ b/backend/services/collaborationService/src/services/collaborationSessionService.ts
@@ -514,7 +514,9 @@ export class CollaborationSessionService {
                 assignedUserIds,
             );
 
-            // Also end if this user left and the other is disconnected (not coming back)
+            // Also end if this user left and the other is disconnected with expired grace period.
+            // If the other user is disconnected but still within their reconnection grace period,
+            // defer the session end — the periodic check will clean up if they don't reconnect.
             if (!sessionEnded) {
                 const otherUserId = assignedUserIds.find((id) => id !== userId);
                 if (otherUserId) {
@@ -523,7 +525,27 @@ export class CollaborationSessionService {
                         otherUserId,
                     );
                     if (otherStatus === "disconnected") {
-                        sessionEnded = true;
+                        const rejoinCheck =
+                            await this.redisPresenceRepository.canRejoinWithinGracePeriod(
+                                binding.collaborationId,
+                                otherUserId,
+                                env.disconnectGraceMs,
+                            );
+                        if (!rejoinCheck.canRejoin) {
+                            // Grace period expired — end immediately
+                            sessionEnded = true;
+                        } else {
+                            logger.info(
+                                {
+                                    collaborationId: binding.collaborationId,
+                                    leavingUserId: userId,
+                                    disconnectedUserId: otherUserId,
+                                    remainingGraceMs:
+                                        rejoinCheck.gracePeriodMs - rejoinCheck.disconnectDurationMs,
+                                },
+                                "User left but partner is disconnected within grace period; deferring session end",
+                            );
+                        }
                     }
                 }
             }
@@ -684,6 +706,40 @@ export class CollaborationSessionService {
         }
 
         return inactiveSessionIds;
+    }
+
+    /**
+     * Find sessions where one user has left and the other user's disconnect grace period has expired.
+     * Called by the periodic inactivity check to clean up deferred session ends.
+     */
+    async getSessionsWithExpiredGrace(gracePeriodMs: number): Promise<string[]> {
+        const activeSessions = await this.redisSessionRepository.getActiveSessions();
+        const expiredSessionIds: string[] = [];
+
+        for (const session of activeSessions) {
+            const assignedUserIds = [session.userAId, session.userBId];
+            const participants = await this.redisPresenceRepository.getParticipants(
+                session.collaborationId,
+                assignedUserIds,
+            );
+
+            const leftUser = participants.find((p) => p.status === "left");
+            const disconnectedUser = participants.find((p) => p.status === "disconnected");
+
+            if (leftUser && disconnectedUser) {
+                const rejoinCheck =
+                    await this.redisPresenceRepository.canRejoinWithinGracePeriod(
+                        session.collaborationId,
+                        disconnectedUser.userId,
+                        gracePeriodMs,
+                    );
+                if (!rejoinCheck.canRejoin) {
+                    expiredSessionIds.push(session.collaborationId);
+                }
+            }
+        }
+
+        return expiredSessionIds;
     }
 
     /**

--- a/backend/services/collaborationService/src/sockets/registerSocketHandlers.ts
+++ b/backend/services/collaborationService/src/sockets/registerSocketHandlers.ts
@@ -715,18 +715,19 @@ export function registerSocketHandlers(io: Server): ReturnType<typeof setInterva
             const acquired = await redis.set(lockKey, "1", "NX", "PX", lockDurationMs);
             if (!acquired) return;
 
-            const inactiveSessionIds = await collaborationSessionService.getInactiveSessions(
-                env.sessionInactivityTimeoutMs,
-            );
+            const { inactiveIds, graceExpiredIds } =
+                await collaborationSessionService.getSessionsToCleanup(
+                    env.sessionInactivityTimeoutMs,
+                    env.disconnectGraceMs,
+                );
 
-            for (const collaborationId of inactiveSessionIds) {
+            for (const collaborationId of inactiveIds) {
                 const endResult = await collaborationSessionService.endSession(
                     collaborationId,
                     "inactivity_timeout",
                 );
 
                 if (endResult) {
-                    // Notify all users in the session that it has ended
                     io.to(collaborationRoom(collaborationId)).emit(SOCKET_EVENTS.SESSION_ENDED, {
                         collaborationId,
                         reason: "inactivity_timeout",
@@ -738,10 +739,6 @@ export function registerSocketHandlers(io: Server): ReturnType<typeof setInterva
                     );
                 }
             }
-
-            // Check for sessions where one user left and the other's disconnect grace period expired
-            const graceExpiredIds =
-                await collaborationSessionService.getSessionsWithExpiredGrace(env.disconnectGraceMs);
 
             for (const collaborationId of graceExpiredIds) {
                 const endResult = await collaborationSessionService.endSession(

--- a/backend/services/collaborationService/src/sockets/registerSocketHandlers.ts
+++ b/backend/services/collaborationService/src/sockets/registerSocketHandlers.ts
@@ -738,6 +738,29 @@ export function registerSocketHandlers(io: Server): ReturnType<typeof setInterva
                     );
                 }
             }
+
+            // Check for sessions where one user left and the other's disconnect grace period expired
+            const graceExpiredIds =
+                await collaborationSessionService.getSessionsWithExpiredGrace(env.disconnectGraceMs);
+
+            for (const collaborationId of graceExpiredIds) {
+                const endResult = await collaborationSessionService.endSession(
+                    collaborationId,
+                    "both_users_left",
+                );
+
+                if (endResult) {
+                    io.to(collaborationRoom(collaborationId)).emit(SOCKET_EVENTS.SESSION_ENDED, {
+                        collaborationId,
+                        reason: "both_users_left",
+                    });
+
+                    logger.info(
+                        { collaborationId, reason: "disconnect_grace_expired" },
+                        "Session ended - user left and partner's disconnect grace period expired",
+                    );
+                }
+            }
         } catch (error) {
             logger.error({ err: error }, "Error checking for inactive sessions");
         }


### PR DESCRIPTION
Previously if User A disconnects and User B leaves, the session will be marked closed and removed. Now, it waits for User A's disconnection grace period to expire before marking it as closed